### PR TITLE
remove css from build for compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,135 +8,146 @@ A scheduler and resource planning component built for React and made for modern 
 [Online demo](https://stephenchou1017.github.io/scheduler/#/)
 
 <!-- MANPAGE: BEGIN EXCLUDED SECTION -->
-* [Main Changes](#main-changes)
-* [Use and Setup](#use-and-setup)
-    * [Install](#npm)
-    * [Example code](#example-code)
-* [Run examples locally](#run-examples-locally)
-* [API](#api)
-    * [SchedulerData](#schedulerdata)
-    * [Locale support](#locale-supportrefer-to-this-example-for-details)
-    * [SchedulerData.config](#schedulerdataconfigsee-the-configjs-for-details)
-    * [SchedulerData.behaviors](#schedulerdatabehaviorssee-the-behaviorsjs-for-details)
-    * [Scheduler.propTypes](#schedulerproptypes)
+
+- [Main Changes](#main-changes)
+- [Use and Setup](#use-and-setup)
+  - [Install](#npm)
+  - [Example code](#example-code)
+- [Run examples locally](#run-examples-locally)
+- [API](#api)
+_ [SchedulerData](#schedulerdata)
+_ [Locale support](#locale-supportrefer-to-this-example-for-details)
+_ [SchedulerData.config](#schedulerdataconfigsee-the-configjs-for-details)
+_ [SchedulerData.behaviors](#schedulerdatabehaviorssee-the-behaviorsjs-for-details) \* [Scheduler.propTypes](#schedulerproptypes)
 <!-- MANPAGE: END EXCLUDED SECTION -->
 
 ## Main Changes
+
 This forks uses the latest antd and react versions and improves the performance significantly as well as some other changes such as:
+
 - Add Spin when changing view and selecting date through SchedulerData config option `viewChangeSpinEnabled` and `dateChangeSpinEnabled` (both true by default)
 - Replace Dayjs.js with Day.js
 - Change event item popover trigger through SchedulerData config option `eventItemPopoverTrigger` ('hover' | 'click'), 'hover' by default
 - Set a fixed height for the scheduler through the SchedulerData config option `schedulerContentHeight` ('500px' by default)
-- Enable/disable react dnd through SchedulerData config option `dragAndDropEnabled` (true by default) 
+- Enable/disable react dnd through SchedulerData config option `dragAndDropEnabled` (true by default)
 - Drop IE support
 - Upgrade react-dnd to v14.0.5 leading to [changes in how we write the `withDnDContext`](https://github.com/hbatalhaStch/react-big-scheduler/blob/master/example/withDnDContext.js) wrapper
 
 ## Use and Setup
 
-#### npm
+#### 1.) Install
+
 `npm i react-big-scheduler-stch`
 
+#### 2.) Import dependencies
 
-#### Example code
 ```js
-//1. import
-import Scheduler, {SchedulerData, ViewType, DATE_FORMAT} from 'react-big-scheduler-stch'
-import dayjs from 'dayjs'
-...
+import Scheduler, {
+  SchedulerData,
+  ViewType,
+  DATE_FORMAT,
+} from "react-big-scheduler-stch";
+import "react-big-scheduler-stch/lib/css/style.css";
+import dayjs from "dayjs";
+```
 
-//2. create the view model, put it in the props obj
-let schedulerData = new SchedulerData(new dayjs().format(DATE_FORMAT), ViewType.Week);
+#### 2.) Basic usage
+
+```js
+const schedulerData = new SchedulerData(
+  new dayjs().format(DATE_FORMAT),
+  ViewType.Week
+);
+
 //set locale dayjs to the schedulerData, if your locale isn't English. By default, Scheduler comes with English(en, United States).
-schedulerData.setSchedulerLocale('pt-br'); // this uses dayjs, but it doesn't require dayjs to be installed as its called dynamically
-schedulerData.setCalendarPopoverLocale('pt_BR'); // this uses antd [List of supported locales](https://ant.design/docs/react/i18n#supported-languages)
-//set resources here or later
-let resources = [
-                    {
-                       id: 'r0',
-                       name: 'Resource0',
-                       groupOnly: true
-                    },
-                    {
-                       id: 'r1',
-                       name: 'Resource1'
-                    },
-                    {
-                       id: 'r2',
-                       name: 'Resource2',
-                       parentId: 'r0'
-                    },
-                    {
-                       id: 'r3',
-                       name: 'Resource3',
-                       parentId: 'r4'
-                    },
-                    {
-                       id: 'r4',
-                       name: 'Resource4',
-                       parentId: 'r2'
-                    },
-                ];
-schedulerData.setResources(resources);
-//set events here or later,
-//the event array should be sorted in ascending order by event.start property, otherwise there will be some rendering errors
-let events = [
-                {
-                     id: 1,
-                     start: '2017-12-18 09:30:00',
-                     end: '2017-12-19 23:30:00',
-                     resourceId: 'r1',
-                     title: 'I am finished',
-                     bgColor: '#D9D9D9'
-                 },
-                 {
-                     id: 2,
-                     start: '2017-12-18 12:30:00',
-                     end: '2017-12-26 23:30:00',
-                     resourceId: 'r2',
-                     title: 'I am not resizable',
-                     resizable: false
-                 },
-                 {
-                     id: 3,
-                     start: '2017-12-19 12:30:00',
-                     end: '2017-12-20 23:30:00',
-                     resourceId: 'r3',
-                     title: 'I am not movable',
-                     movable: false
-                 },
-                 {
-                     id: 4,
-                     start: '2017-12-19 14:30:00',
-                     end: '2017-12-20 23:30:00',
-                     resourceId: 'r1',
-                     title: 'I am not start-resizable',
-                     startResizable: false
-                 },
-                 {
-                     id: 5,
-                     start: '2017-12-19 15:30:00',
-                     end: '2017-12-20 23:30:00',
-                     resourceId: 'r2',
-                     title: 'R2 has recurring tasks every week on Tuesday, Friday',
-                     rrule: 'FREQ=WEEKLY;DTSTART=20171219T013000Z;BYDAY=TU,FR',
-                     bgColor: '#f759ab'
-                 }
-             ];
-schedulerData.setEvents(events);
+schedulerData.setSchedulerLocale("pt-br"); // this uses dayjs, but it doesn't require dayjs to be installed as its called dynamically
+schedulerData.setCalendarPopoverLocale("pt_BR"); // this uses antd [List of supported locales](https://ant.design/docs/react/i18n#supported-languages)
 
-...
+schedulerData.setResources([
+  {
+    id: "r0",
+    name: "Resource0",
+    groupOnly: true,
+  },
+  {
+    id: "r1",
+    name: "Resource1",
+  },
+  {
+    id: "r2",
+    name: "Resource2",
+    parentId: "r0",
+  },
+  {
+    id: "r3",
+    name: "Resource3",
+    parentId: "r4",
+  },
+  {
+    id: "r4",
+    name: "Resource4",
+    parentId: "r2",
+  },
+]);
+
+// the event array should be sorted in ascending order by event.start property
+// otherwise there will be some rendering errors
+schedulerData.setEvents([
+  {
+    id: 1,
+    start: "2017-12-18 09:30:00",
+    end: "2017-12-19 23:30:00",
+    resourceId: "r1",
+    title: "I am finished",
+    bgColor: "#D9D9D9",
+  },
+  {
+    id: 2,
+    start: "2017-12-18 12:30:00",
+    end: "2017-12-26 23:30:00",
+    resourceId: "r2",
+    title: "I am not resizable",
+    resizable: false,
+  },
+  {
+    id: 3,
+    start: "2017-12-19 12:30:00",
+    end: "2017-12-20 23:30:00",
+    resourceId: "r3",
+    title: "I am not movable",
+    movable: false,
+  },
+  {
+    id: 4,
+    start: "2017-12-19 14:30:00",
+    end: "2017-12-20 23:30:00",
+    resourceId: "r1",
+    title: "I am not start-resizable",
+    startResizable: false,
+  },
+  {
+    id: 5,
+    start: "2017-12-19 15:30:00",
+    end: "2017-12-20 23:30:00",
+    resourceId: "r2",
+    title: "R2 has recurring tasks every week on Tuesday, Friday",
+    rrule: "FREQ=WEEKLY;DTSTART=20171219T013000Z;BYDAY=TU,FR",
+    bgColor: "#f759ab",
+  },
+]);
+
+// ...
 
 //3. render the scheduler component, mind that the Scheduler component should be placed in a DragDropContext(father or ancestor).
-...
-const {schedulerData} = this.props;
-<Scheduler schedulerData={schedulerData}
-           prevClick={this.prevClick}
-           nextClick={this.nextClick}
-           onSelectDate={this.onSelectDate}
-           onViewChange={this.onViewChange}
-           eventItemClick={this.eventClicked}
-/>
-...
+
+<Scheduler
+  schedulerData={schedulerData}
+  prevClick={this.prevClick}
+  nextClick={this.nextClick}
+  onSelectDate={this.onSelectDate}
+  onViewChange={this.onViewChange}
+  eventItemClick={this.eventClicked}
+/>;
 ```
 
 ## Run examples locally
@@ -202,7 +213,9 @@ If your locale isn't English. By default, Scheduler comes with English(en, Unite
 ```js
 setCalendarPopoverLocale(lang);
 ```
+
 Used to set locale to the calendar popover. it uses antd locales ([List of supported locales](https://ant.design/docs/react/i18n#supported-languages). By default, it comes with English(en, United States)
+
 #### setResources
 
 ```js
@@ -432,9 +445,6 @@ getViewEndDate();
 
 Returns a dayjs object with the endDate of the currently selected view.
 
-
-
-
 ### Locale support(Refer to [this example](https://stephenchou1017.github.io/scheduler/#/locale) for details.)
 
 #### SchedulerData.config.resourceName
@@ -477,14 +487,14 @@ The width of Scheduler. Scheduler uses responsive layout so schedulerWidth shoul
 Scheduler in the responsive layout:
 `actual width of Scheduler = (SchedulerData.documentWidth - SchedulerData.config.besidesWidth) * SchedulerData.config.schedulerWidth`
 `SchedulerData.documentWidth` is the window width of browser (or the the parent width in case SchedulerData.config.responsiveByParent
- and Scheduler component prop parentRef is passed) and will change automatically when resized.
+and Scheduler component prop parentRef is passed) and will change automatically when resized.
 
 #### responsiveByParent
 
-When true, Scheduler resposiveness will not be determined by the window width of browser but instead by the 
+When true, Scheduler resposiveness will not be determined by the window width of browser but instead by the
 width of the of the parent (the parent ref must be passed to the Scheduler component prop named `parentRef`,
-in case it is not passed resposiveness will fall back to being determined by the window width). 
-Meaning: 
+in case it is not passed resposiveness will fall back to being determined by the window width).
+Meaning:
 `SchedulerData.documentWidth` is the width of the parent and will change automatically when resized
 
 #### schedulerMaxHeight
@@ -656,7 +666,7 @@ Minute step for day view type in non-agenda view, can be 10, 12, 15, 20, 30, 60,
 
 Array of view that Scheduler will support.
 
-#### dragAndDropEnabled 
+#### dragAndDropEnabled
 
 Controls whether the dragAndDrop funcionality is enabled. If false there's no need for the [withDnDContext wrapper](https://github.com/hbatalhaStch/react-big-scheduler/blob/master/example/withDnDContext.js).
 

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,66 +1,53 @@
-'use strict';
+"use strict";
 
 // Do this as the first thing so that any code reading it knows the right env.
-process.env.BABEL_ENV = 'production';
-process.env.NODE_ENV = 'production';
+process.env.BABEL_ENV = "production";
+process.env.NODE_ENV = "production";
 
 // Makes the script crash on unhandled rejections instead of silently
 // ignoring them. In the future, promise rejections that are not handled will
 // terminate the Node.js process with a non-zero exit code.
-process.on('unhandledRejection', err => {
+process.on("unhandledRejection", (err) => {
   throw err;
 });
 
-const util = require('util');
-const path = require('path');
-const exec = util.promisify(require('child_process').exec);
-const fs = require('fs-extra')
+const util = require("util");
+const path = require("path");
+const exec = util.promisify(require("child_process").exec);
+const fs = require("fs-extra");
 
 async function build() {
-  const root = path.resolve(__dirname, '..');
-  const sourceDir = path.resolve(root, 'src');
-  const targetDir = path.resolve(root, 'lib');
+  const root = path.resolve(__dirname, "..");
+  const sourceDir = path.resolve(root, "src");
+  const targetDir = path.resolve(root, "lib");
   const jsTarget = targetDir;
-  const cssTarget = path.resolve(targetDir, 'css');
-
+  const cssTarget = path.resolve(targetDir, "css");
 
   try {
     // clean
-    process.stdout.write('Cleaning... \n');
-    const cleanResult = await exec('npm run clean');
+    process.stdout.write("Cleaning... \n");
+    const cleanResult = await exec("npm run clean");
 
     // transpiling and copy js
-    process.stdout.write('Transpiling js with babel... \n');
+    process.stdout.write("Transpiling js with babel... \n");
     const jsResult = await exec(`babel ${sourceDir} --out-dir ${jsTarget}`);
 
-    process.stdout.write('Copying type definitions... \n');
+    process.stdout.write("Copying type definitions... \n");
     await fs.copy(`${sourceDir}/css/`, cssTarget);
 
-    process.stdout.write('Copying library style definitions... \n');
+    process.stdout.write("Copying library style definitions... \n");
     await fs.copy(`${root}/typing/index.d.ts`, `${targetDir}/index.d.ts`);
 
     // local (for hbatalhaStch only)
     if (fs.existsSync(`${targetDir}/DemoData-dev.js`)) {
-      process.stdout.write('Removing a dev file... \n');
-      fs.unlinkSync(`${targetDir}/DemoData-dev.js`)
+      process.stdout.write("Removing a dev file... \n");
+      fs.unlinkSync(`${targetDir}/DemoData-dev.js`);
     }
 
-    process.stdout.write('Adding css to index.js... \n');
-    await fs.appendFile(
-      `${targetDir}/index.js`,
-      [
-        '',
-        '',
-        '// this line has been added by scripts/build.js',
-        "require('./css/style.css');",
-        '',
-      ].join('\n')
-    );
-
-    process.stdout.write('Success! \n');
+    process.stdout.write("Success! \n");
   } catch (e) {
-    console.log(e)
-    process.exit()
+    console.log(e);
+    process.exit();
   }
 }
 


### PR DESCRIPTION
### Problem

- Next.js does not like modules to have direct `css` imports:

```
ready - started server on http://localhost:3000
info  - automatically enabled Fast Refresh for 1 custom loader
wait  - compiling /_error (client and server)...
error - ../../node_modules/react-big-scheduler-stch/lib/css/style.css
Global CSS cannot be imported from within node_modules.
Read more: https://nextjs.org/docs/messages/css-npm
Location: ../../node_modules/react-big-scheduler-stch/lib/index.js
```

### Approach

- Remove the line in the build system that was adding the compiled CSS
- Update the Readme to include documentation on adding the required css file.

[Related issue](https://github.com/hbatalhaStch/react-big-scheduler/issues/3)

CC @hbatalhaStch 