### PR TITLE
ensure window object exists for ssr support

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -71,7 +71,10 @@ class Scheduler extends Component {
 
         if ((schedulerData.isSchedulerResponsive() && !schedulerData.config.responsiveByParent) || parentRef === undefined) {
             schedulerData._setDocumentWidth(document.documentElement.clientWidth);
-            window.onresize = this.onWindowResize;
+            // Skip this binding if window object is not available. (Allows this to work in Next.js)
+            if (typeof window !== 'undefined'){
+                window.onresize = this.onWindowResize;
+            }
         }
     }
 


### PR DESCRIPTION
### Problem

Frameworks like Next that support SSR components will attempt to render things server-side where the `window` object does not exist. 
See: https://github.com/hbatalhaStch/react-big-scheduler/issues/3

### Approach

- Make sure the `window` object exists before binding events to it.